### PR TITLE
Require parts for body mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,109 @@
 # FEP
-pythonTextGame
+
+FEP stands for "Far East Project." This repository contains a simple text-based
+life simulation game set in a far-future Seoul and beyond. All in-game text is in Korean.
+
+## Running the Game
+
+```bash
+python game.py
+```
+
+
+During the game you will be prompted in Korean to choose among four main categories:
+
+1. **이동** – 장소나 국가를 바꿉니다.
+2. **NPC 선택** – 같은 장소에 있는 인물과 상호작용합니다.
+3. **행동** – 일하기, 식사, 잠자기, 탐험 등의 활동을 수행합니다.
+4. **메뉴** – 게임 종료 등 기타 기능을 선택합니다.
+
+이 세계에는 네 개의 주요 국가가 존재합니다: **인류연합국**, **거합**, **탐랑**, 그리고 **전계국**입니다. 거합은 인간이 동식물에게 가한 실험으로 지능을 얻은 존재들이 모여 만든 나라이고, 탐랑은 개성을 중시해 오프라인으로 방랑하는 기계들의 느슨한 모임입니다. 전계국은 이들을 고장난 집단으로 여기며 모든 기계를 하나로 묶으려 합니다.
+
+### Player Stats
+
+Characters have six core attributes:
+
+- **Strength**
+- **Perception**
+- **Endurance** – affects maximum health and 기력 as well as recovery rates
+- **Charisma**
+- **Intelligence**
+- **Agility** – higher agility lets your turn gauge fill faster in battle
+
+These values influence activities like working and exploring. From these base attributes the game derives secondary stats used in daily life:
+
+- **포만감** – how full you are, decreases with time and activities
+- **기력** – stamina for actions, mainly restored by sleeping
+- **청결도** – gets lower over time or when exploring, restored by washing
+
+The maximum values and recovery rates of these secondary stats scale with the primary attributes such as Endurance or Charisma.
+
+### NPC Interactions
+
+게임에는 개성 있는 여러 캐릭터가 존재합니다. 각 캐릭터는 호감도를
+가지고 있으며 시간대에 따라 다른 장소에서 생활합니다. 플레이어는
+동일한 장소에 있을 때 대화하거나 거래하고, 필요하면 돈을 빌리거나
+전투를 벌일 수 있습니다.
+
+### 캐릭터 정의
+
+플레이어와 NPC에 대한 능력치와 스케줄, 성격 정보는 `data/characters.json`
+파일에 기록되어 있으며 로딩 시 `characters.py`가 이를 읽어 들입니다.
+JSON 형식이라 새로운 NPC를 손쉽게 추가하거나 수정할 수 있습니다.
+
+### 장소
+
+모든 장소와 국가 정보는 `data/locations.json`에 정의되어 있으며
+`locations.py`에서 읽어 들여 객체로 변환합니다. 게임을 시작하면 "시스템 초기화" 메시지 후
+인류연합국의 지하 거대한 하수도에서 눈을 뜨게 되며, 연결된 장소로
+이동하며 탐험할 수 있습니다. `장소 이동` 옵션을 사용하여 현재 위치와
+연결된 다른 지역으로 갈 수 있습니다.
+
+일부 장소는 처음에는 보이지 않으며, 같은 장소에서 `탐험`을 수행하고
+충분한 지각 능력을 갖추었을 때만 발견됩니다. 숨겨진 경로를 찾으면
+해당 장소가 이동 목록에 추가됩니다.
+
+### GUI
+
+`gui.py`는 플레이어의 상태와 현재 위치 정보를 보기 좋게 출력해 주는
+간단한 텍스트 인터페이스를 제공합니다. 화면의 상단에는 건강 상태와
+기본 스탯이 표시되고, 구분선 아래에는 장소 묘사와 주변 인물 목록,
+또 다른 구분선 아래에는 이동 가능한 다른 장소가 나열됩니다.
+
+### 인벤토리
+
+플레이어는 장비에 따라 들 수 있는 물건의 무게가 결정됩니다. 기본 용량은
+5이고, 주머니가 달린 옷이나 가방을 장비하면 추가 용량이 늘어납니다.
+가방 종류에 따라 추가 용량이 다르며, 여행용 캐리어나 카트를 사용하면
+훨씬 많은 물건을 운반할 수 있습니다. 카트의 경우 크기에 따라 건물 내부로
+들어갈 수 있는지 여부가 달라집니다(대형 카트는 실내 진입이 어렵습니다).
+아이템마다 무게가 정해져 있어 현재 들고 있는 총 무게가 용량을 초과하면
+새로운 물건을 넣을 수 없습니다. `행동` 메뉴에서 **소지품 확인**이나
+**씻기** 등을 선택해 일상적인 관리도 할 수 있습니다.
+아이템 정보는 `data/items.json`에 정리되어 있어 무게나 이름을 손쉽게
+수정하거나 새로운 아이템을 추가할 수 있습니다.
+
+지각(**Perception**) 수치가 낮으면 무게와 부피를 정확히 파악하기 어렵기
+때문에, 소지품 목록과 상태 창에 표시되는 수치는 오차가 생길 수 있습니다.
+지각이 높을수록 이러한 오차 범위가 줄어들어 실제 값과 거의 같게 보입니다.
+
+### 신체 개조와 장비
+
+`equipment.py`에는 가방 같은 장비와 신체 개조 모듈이 정의되어 있습니다.
+플레이어는 특정 부위에 사이버네틱 개조를 장착해 능력치를 올릴 수 있으며,
+게임 내에서 **신체 개조** 행동을 통해 원하는 모듈을 설치할 수 있습니다.
+모드마다 설치를 위한 전용 부품이 존재하므로 인벤토리에 해당 부품을
+소지하고 있어야 시술이 가능합니다.
+눈 개조의 경우 여러 기업이 서로 다른 기능을 제공합니다. 예를 들어
+"아이리움"사의 적외선 강화 눈은 투명화된 생물을 감지할 수 있고,
+"정밀전자"의 분석용 눈은 정확한 타격 확률을 높여 주지만 고성능
+기능을 사용하려면 추가로 뇌 인터페이스 모듈을 장착해야 합니다. 왼쪽과
+오른쪽 눈을 각각 다르게 개조하는 것도 가능합니다.
+장착된 개조는 상태 창에서 확인할 수 있습니다.
+
+### 전투
+
+NPC와 싸우게 되면 전투는 턴제로 진행됩니다. 각 참여자는 "턴 게이지"
+가 0이 될 때마다 차례가 돌아옵니다. 민첩(**Agility**) 수치가 높을수록
+턴 게이지가 더 빨리 소모되어 보다 자주 행동할 수 있습니다. 전투 로직은
+`battle.py`에 구현되어 있습니다.

--- a/battle.py
+++ b/battle.py
@@ -1,0 +1,32 @@
+import random
+
+
+def gauge_cost(agility):
+    """Return how much of the turn gauge is consumed per tick."""
+    return min(99, 50 + agility * 5)
+
+
+def start_battle(player, npc):
+    """Run a simple turn-based battle between player and npc."""
+    print(f"{npc.name}과(와) 전투를 시작합니다!")
+    gauges = {player: 100, npc: 100}
+    while player.health > 0 and npc.health > 0:
+        gauges[player] -= gauge_cost(player.agility)
+        gauges[npc] -= gauge_cost(npc.agility)
+        if gauges[player] <= 0:
+            dmg = random.randint(5, 10) + player.strength
+            npc.health -= dmg
+            print(f"당신의 공격! {npc.name}에게 {dmg}의 피해를 주었습니다.")
+            gauges[player] = 100
+            if npc.health <= 0:
+                break
+        if gauges[npc] <= 0:
+            dmg = random.randint(5, 10)
+            player.health -= dmg
+            print(f"{npc.name}의 공격! {dmg}의 피해를 받았습니다.")
+            gauges[npc] = 100
+    if player.health <= 0:
+        print("당신이 쓰러졌습니다...")
+    else:
+        print(f"{npc.name}을(를) 쓰러뜨렸습니다!")
+        npc.affinity = max(0, npc.affinity - 20)

--- a/characters.py
+++ b/characters.py
@@ -1,0 +1,269 @@
+import json
+import os
+import random
+
+from items import BROKEN_PART
+from equipment import (
+    Equipment,
+    CLOTHES_WITH_POCKETS,
+    BASIC_BAG,
+)
+
+from locations import (
+    NATIONS,
+    DEFAULT_LOCATION_BY_NATION,
+    LOCATIONS,
+)
+
+LOCATIONS_BY_KEY = {getattr(loc, "key", loc.name): loc for loc in LOCATIONS}
+
+TIME_OF_DAY = ["아침", "낮", "밤"]
+
+class Character:
+    def __init__(self, name, personality, affiliation, job, schedule, agility=5):
+        self.name = name
+        self.personality = personality
+        self.affiliation = affiliation
+        self.job = job
+        self.schedule = schedule  # time index -> Location
+        if schedule:
+            self.location = schedule.get(0, next(iter(schedule.values())))
+        else:
+            self.location = DEFAULT_LOCATION_BY_NATION[NATIONS[0]]
+        self.affinity = 50
+        self.health = 50
+        self.agility = agility
+
+    def update_location(self, time_idx):
+        self.location = self.schedule.get(time_idx, self.location)
+
+    def talk(self, player):
+        if self.affinity >= 70:
+            print(f"{self.name}은(는) 반갑게 당신을 맞이합니다.")
+        elif self.affinity >= 30:
+            print(f"{self.name}은(는) 무난하게 대화에 응합니다.")
+        else:
+            print(f"{self.name}은(는) 시큰둥한 반응을 보입니다.")
+        gain = max(1, player.charisma // 2)
+        self.affinity = min(100, self.affinity + gain)
+
+    def trade(self, player):
+        price = 5
+        if player.money < price:
+            print("돈이 부족합니다.")
+            return
+        player.money -= price
+        player.satiety = min(player.max_satiety, player.satiety + 20 + player.endurance)
+        player.stamina = min(player.max_stamina, player.stamina + 10 + player.strength // 2)
+        print(f"{self.name}에게서 음식을 구입했습니다.")
+
+    def lend_money(self, player):
+        if self.affinity >= 60:
+            amount = 10
+            player.money += amount
+            self.affinity -= 5
+            print(f"{self.name}은(는) {amount}원을 빌려주었습니다.")
+        else:
+            print(f"{self.name}은(는) 돈을 빌려주지 않습니다.")
+
+    def fight(self, player):
+        from battle import start_battle
+
+        start_battle(player, self)
+
+
+def _load_npcs():
+    path = os.path.join(os.path.dirname(__file__), "data", "characters.json")
+    with open(path, encoding="utf-8") as f:
+        raw = json.load(f)
+    loc_map = LOCATIONS_BY_KEY
+    npcs = []
+    for entry in raw.get("npcs", []):
+        schedule = {int(k): loc_map[v] for k, v in entry.get("schedule", {}).items()}
+        npcs.append(
+            Character(
+                entry["name"],
+                entry.get("personality", ""),
+                entry.get("affiliation", ""),
+                entry.get("job", ""),
+                schedule,
+                agility=entry.get("agility", 5),
+            )
+        )
+    return npcs
+
+
+NPCS = _load_npcs()
+
+class Player:
+    def __init__(self, name):
+        self.name = name
+        # 기본 능력치
+        self.strength = 5
+        self.perception = 5
+        self.endurance = 5
+        self.charisma = 5
+        self.intelligence = 5
+        self.agility = 5
+
+        self.max_health = 100 + self.endurance * 10
+        self.max_stamina = 100 + self.endurance * 5
+        self.max_satiety = 100 + self.endurance * 2
+        self.max_cleanliness = 100 + self.charisma * 2
+
+        self.health = self.max_health
+        self.stamina = self.max_stamina
+        self.satiety = self.max_satiety
+        self.cleanliness = self.max_cleanliness
+        self.money = 20
+        self.experience = 0
+        self.day = 1
+        self.location = DEFAULT_LOCATION_BY_NATION[NATIONS[0]]
+        self.time = 0  # 0=아침,1=낮,2=밤
+
+        # Inventory and equipment
+        self.base_capacity = 5
+        self.inventory = []
+        # 테스트용으로 기본 개조 부품 하나를 지급
+        from items import IR_EYE_LEFT_PART
+        self.inventory.append(IR_EYE_LEFT_PART)
+        self.equipment = {
+            "clothing": CLOTHES_WITH_POCKETS,
+            "bag": None,
+        }
+        # installed body modifications by slot
+        self.mods = {}
+
+    def status(self):
+        print(f"\n{self.day}일차 {TIME_OF_DAY[self.time]}")
+        print(f"{self.name}의 상태:")
+        print(f"건강: {self.health}/{self.max_health}")
+        print(f"포만감: {self.satiety}/{self.max_satiety}")
+        print(f"기력: {self.stamina}/{self.max_stamina}")
+        print(f"청결도: {self.cleanliness}/{self.max_cleanliness}")
+        print(f"돈: {self.money}원")
+        print(f"경험치: {self.experience}")
+        print(f"현재 위치: {self.location.name} ({self.location.nation.name})")
+        nearby = [c.name for c in NPCS if c.location == self.location]
+        if nearby:
+            print("주변 인물: " + ", ".join(nearby))
+        print()
+        print(f"힘: {self.strength}")
+        print(f"지각: {self.perception}")
+        print(f"인내심: {self.endurance}")
+        print(f"매력: {self.charisma}")
+        print(f"지능: {self.intelligence}")
+        print(f"민첩: {self.agility}")
+        if self.mods:
+            print("개조: " + ", ".join(m.name for m in self.mods.values()))
+        est = self.estimated_weight()
+        est_text = str(est) if self.perception >= 10 else f"약 {est}"
+        print(f"소지 무게: {est_text}/{self.carrying_capacity()}\n")
+
+    def is_alive(self):
+        return self.health > 0
+
+    def end_day(self):
+        self.day += 1
+        self.satiety -= 5
+        self.cleanliness -= 10
+        if self.satiety <= 0:
+            self.health += self.satiety
+            self.satiety = 0
+        if self.stamina <= 0:
+            self.health += self.stamina
+            self.stamina = 0
+        if self.health > self.max_health:
+            self.health = self.max_health
+        if self.cleanliness < 0:
+            self.cleanliness = 0
+        self.recalc_derived_stats()
+
+    def recalc_derived_stats(self):
+        self.max_health = 100 + self.endurance * 10
+        self.max_stamina = 100 + self.endurance * 5
+        self.max_satiety = 100 + self.endurance * 2
+        self.max_cleanliness = 100 + self.charisma * 2
+        self.health = min(self.health, self.max_health)
+        self.stamina = min(self.stamina, self.max_stamina)
+        self.satiety = min(self.satiety, self.max_satiety)
+        self.cleanliness = min(self.cleanliness, self.max_cleanliness)
+
+    # Inventory helpers
+    def carrying_capacity(self):
+        cap = self.base_capacity
+        for eq in self.equipment.values():
+            if eq:
+                cap += eq.capacity
+        return cap
+
+    def current_weight(self):
+        return sum(item.weight for item in self.inventory)
+
+    def estimate_value(self, value):
+        """Return an estimated measurement influenced by perception."""
+        if self.perception >= 10:
+            return value
+        error_ratio = (10 - self.perception) / 10
+        factor = random.uniform(-error_ratio, error_ratio)
+        return max(0, round(value * (1 + factor), 1))
+
+    def estimated_weight(self):
+        return sum(self.estimate_value(it.weight) for it in self.inventory)
+
+    def can_carry(self, item):
+        return self.current_weight() + item.weight <= self.carrying_capacity()
+
+    def add_item(self, item):
+        if self.can_carry(item):
+            self.inventory.append(item)
+            print(f"{item.name}을(를) 획득했습니다.")
+        else:
+            print(f"{item.name}은(는) 너무 무거워서 들 수 없습니다.")
+
+    def show_inventory(self):
+        if not self.inventory:
+            print("소지품이 없습니다.")
+        else:
+            print("소지품:")
+            for it in self.inventory:
+                est_w = self.estimate_value(it.weight)
+                est_v = self.estimate_value(getattr(it, "volume", 0))
+                w_text = str(est_w) if self.perception >= 10 else f"약 {est_w}"
+                v_text = str(est_v) if self.perception >= 10 else f"약 {est_v}"
+                print(f"- {it.name} (무게 {w_text}, 부피 {v_text})")
+            total = self.estimated_weight()
+            if self.perception < 10:
+                total_text = f"약 {total}"
+            else:
+                total_text = str(total)
+            print(f"총 무게 {total_text}/{self.carrying_capacity()}")
+
+    # Body modification helpers
+    def install_mod(self, mod):
+        if mod.required_item and mod.required_item not in self.inventory:
+            print(f"{mod.required_item.name}이(가) 없어 개조를 진행할 수 없습니다.")
+            return
+        if mod.required_item and mod.required_item in self.inventory:
+            self.inventory.remove(mod.required_item)
+        current = self.mods.get(mod.slot)
+        if current:
+            print(f"{current.name}을(를) 제거하고 {mod.name}을(를) 장착합니다.")
+            self.remove_mod(current)
+        else:
+            print(f"{mod.name}을(를) 장착합니다.")
+        self.mods[mod.slot] = mod
+        for stat, value in mod.stat_changes.items():
+            setattr(self, stat, getattr(self, stat) + value)
+        self.recalc_derived_stats()
+        if mod.needs_brain and "brain" not in self.mods:
+            print("뇌 인터페이스가 없어 고성능 기능을 이용할 수 없습니다.")
+
+    def remove_mod(self, mod):
+        if self.mods.get(mod.slot) != mod:
+            return
+        del self.mods[mod.slot]
+        for stat, value in mod.stat_changes.items():
+            setattr(self, stat, getattr(self, stat) - value)
+        self.recalc_derived_stats()
+

--- a/data/characters.json
+++ b/data/characters.json
@@ -1,0 +1,20 @@
+{
+  "npcs": [
+    {
+      "name": "상인 정",
+      "personality": "친절한",
+      "affiliation": "인류연합국 상인조합",
+      "job": "상인",
+      "schedule": {"0": "MARKET", "1": "MARKET", "2": "RESIDENTIAL"},
+      "agility": 5
+    },
+    {
+      "name": "로봇 42",
+      "personality": "차가운",
+      "affiliation": "전계국",
+      "job": "경비",
+      "schedule": {"0": "STATION", "1": "STATION", "2": "STATION"},
+      "agility": 5
+    }
+  ]
+}

--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,8 @@
+{
+  "IR_EYE_LEFT_PART": {"name": "아이리움 사이버 눈(좌)", "weight": 1, "volume": 1},
+  "IR_EYE_RIGHT_PART": {"name": "아이리움 사이버 눈(우)", "weight": 1, "volume": 1},
+  "PREC_EYE_LEFT_PART": {"name": "정밀전자 사이버 눈(좌)", "weight": 1, "volume": 1},
+  "PREC_EYE_RIGHT_PART": {"name": "정밀전자 사이버 눈(우)", "weight": 1, "volume": 1},
+  "BRAIN_INTERFACE_CHIP": {"name": "뇌 인터페이스 칩", "weight": 1, "volume": 1},
+  "BROKEN_PART": {"name": "부서진 부품", "weight": 2, "volume": 2}
+}

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,0 +1,30 @@
+{
+  "nations": [
+    {"name": "인류연합국", "description": "인간들로 이루어진 연합 국가"},
+    {"name": "거합", "description": "실험을 통해 지능을 얻은 동식물들이 모여 만든 연합 국가"},
+    {"name": "탐랑", "description": "개성을 중시해 오프라인으로 방랑하는 기계들의 느슨한 모임"},
+    {"name": "전계국", "description": "모든 기계가 하나로 연결되길 바라는 전기와 기계의 나라"}
+  ],
+  "locations": [
+    {"key": "SEWER", "name": "거대한 하수도", "description": "인류연합국 수도 지하를 흐르는 광대한 하수도", "nation": 0, "indoors": true},
+    {"key": "STATION", "name": "지하 정거장", "description": "도시 각지로 통하는 낡은 정거장", "nation": 0, "indoors": true},
+    {"key": "MARKET", "name": "중앙 시장", "description": "사람들로 붐비는 시장 거리", "nation": 0},
+    {"key": "RESIDENTIAL", "name": "주거 지구", "description": "평범한 주거 지역", "nation": 0},
+    {"key": "SECRET_LAB", "name": "비밀 실험실", "description": "하수도 깊숙한 곳에 숨겨진 연구 시설", "nation": 0, "indoors": true},
+    {"key": "CAPITAL_GEOHAP", "name": "거합 수도", "description": "거합의 중심 도시", "nation": 1},
+    {"key": "BASE_TAMRANG", "name": "탐랑 거점", "description": "오프라인 기계들의 집합", "nation": 2},
+    {"key": "HUB_CHONKYE", "name": "전계 허브", "description": "모든 기계가 연결된 중심", "nation": 3}
+  ],
+  "connections": [
+    ["SEWER", "STATION"],
+    ["STATION", "MARKET"],
+    ["STATION", "RESIDENTIAL"],
+    {"from": "SEWER", "to": "SECRET_LAB", "perception": 7}
+  ],
+  "default_locations": {
+    "0": "SEWER",
+    "1": "CAPITAL_GEOHAP",
+    "2": "BASE_TAMRANG",
+    "3": "HUB_CHONKYE"
+  }
+}

--- a/equipment.py
+++ b/equipment.py
@@ -1,0 +1,107 @@
+from items import Item
+
+class Equipment(Item):
+    """Equipment that increases carrying capacity or grants bonuses."""
+
+    def __init__(self, name, weight, capacity, can_enter_buildings=True, volume=1):
+        super().__init__(name, weight, volume)
+        self.capacity = capacity
+        self.can_enter_buildings = can_enter_buildings
+
+
+class BodyMod:
+    """Cybernetic or biological enhancement."""
+
+    def __init__(
+        self,
+        name,
+        slot,
+        stat_changes=None,
+        skills=None,
+        flags=None,
+        required_item=None,
+        company=None,
+        needs_brain=False,
+    ):
+        self.name = name
+        self.slot = slot  # e.g. 'arm', 'eye'
+        self.stat_changes = stat_changes or {}
+        self.skills = skills or []
+        self.flags = flags or []
+        self.required_item = required_item
+        self.company = company
+        self.needs_brain = needs_brain
+
+
+# Default equipment items
+CLOTHES_WITH_POCKETS = Equipment("주머니 달린 옷", 1, 5, volume=1)
+BASIC_BAG = Equipment("소형 가방", 2, 15, volume=2)
+MEDIUM_BAG = Equipment("중형 가방", 3, 25, volume=3)
+LARGE_BAG = Equipment("대형 가방", 4, 35, volume=4)
+TRAVEL_SUITCASE = Equipment("여행용 캐리어", 5, 40, volume=5)
+SMALL_CART = Equipment("소형 카트", 6, 50, volume=6)
+MEDIUM_CART = Equipment("중형 카트", 8, 70, volume=8)
+LARGE_CART = Equipment("대형 카트", 10, 100, can_enter_buildings=False, volume=10)
+
+# Example body modifications
+from items import (
+    IR_EYE_LEFT_PART,
+    IR_EYE_RIGHT_PART,
+    PREC_EYE_LEFT_PART,
+    PREC_EYE_RIGHT_PART,
+    BRAIN_INTERFACE_CHIP,
+)
+
+BRAIN_INTERFACE = BodyMod(
+    "신경 인터페이스",
+    "brain",
+    {},
+    flags=["interface"],
+    required_item=BRAIN_INTERFACE_CHIP,
+)
+IR_EYE_LEFT = BodyMod(
+    "아이리움 적외선 눈(왼쪽)",
+    "eye_left",
+    {"perception": 2},
+    skills=["적외선 감지"],
+    required_item=IR_EYE_LEFT_PART,
+    company="아이리움",
+)
+IR_EYE_RIGHT = BodyMod(
+    "아이리움 적외선 눈(오른쪽)",
+    "eye_right",
+    {"perception": 2},
+    skills=["적외선 감지"],
+    required_item=IR_EYE_RIGHT_PART,
+    company="아이리움",
+)
+PREC_EYE_LEFT = BodyMod(
+    "정밀전자 분석 눈(왼쪽)",
+    "eye_left",
+    {"perception": 2},
+    skills=["정밀 조준"],
+    required_item=PREC_EYE_LEFT_PART,
+    company="정밀전자",
+    needs_brain=True,
+)
+PREC_EYE_RIGHT = BodyMod(
+    "정밀전자 분석 눈(오른쪽)",
+    "eye_right",
+    {"perception": 2},
+    skills=["정밀 조준"],
+    required_item=PREC_EYE_RIGHT_PART,
+    company="정밀전자",
+    needs_brain=True,
+)
+POWER_ARM = BodyMod("강화 팔", "arm", {"strength": 3})
+LIGHT_LEG = BodyMod("경량 다리", "leg", {"agility": 2})
+
+BODY_MODS = [
+    BRAIN_INTERFACE,
+    IR_EYE_LEFT,
+    IR_EYE_RIGHT,
+    PREC_EYE_LEFT,
+    PREC_EYE_RIGHT,
+    POWER_ARM,
+    LIGHT_LEG,
+]

--- a/game.py
+++ b/game.py
@@ -1,0 +1,287 @@
+import random
+
+from locations import (
+    NATIONS,
+    DEFAULT_LOCATION_BY_NATION,
+)
+
+from characters import NPCS, Player
+from items import BROKEN_PART
+from equipment import BODY_MODS
+from gui import draw_screen
+
+class Game:
+    def __init__(self, player):
+        self.player = player
+        self.characters = NPCS
+
+    def update_characters(self):
+        for npc in self.characters:
+            npc.update_location(self.player.time)
+
+    def advance_time(self):
+        self.player.time += 1
+        if self.player.time > 2:
+            self.player.time = 0
+            self.player.end_day()
+
+    def work(self):
+        if self.player.stamina < 20 or self.player.satiety < 20:
+            print("기력이 부족하거나 너무 허기가 져서 일할 수 없습니다.")
+            return
+        income = 10 + self.player.intelligence // 2 + self.player.strength // 2
+        self.player.money += income
+        stamina_cost = max(10, 20 - self.player.strength)
+        satiety_cost = max(5, 10 - self.player.endurance // 2)
+        self.player.stamina -= stamina_cost
+        self.player.satiety -= satiety_cost
+        self.player.cleanliness -= 5
+        self.player.experience += 1
+        print(f"일해서 {income}원을 벌었습니다.")
+
+    def eat(self):
+        if self.player.money < 5:
+            print("음식을 살 돈이 부족합니다.")
+            return
+        self.player.money -= 5
+        gain_satiety = 20 + self.player.endurance
+        gain_stamina = 10 + self.player.strength // 2
+        self.player.satiety = min(self.player.max_satiety, self.player.satiety + gain_satiety)
+        self.player.stamina = min(self.player.max_stamina, self.player.stamina + gain_stamina)
+        heal = self.player.endurance
+        self.player.health = min(self.player.health + heal, self.player.max_health)
+        print(f"식사를 했습니다. 체력이 {heal} 회복되었습니다.")
+
+    def sleep(self):
+        gain_stamina = self.player.endurance * 5 + 20
+        self.player.stamina = min(self.player.max_stamina, self.player.stamina + gain_stamina)
+        self.player.satiety -= 10
+        if self.player.satiety < 0:
+            self.player.satiety = 0
+        heal = 10 + self.player.endurance
+        self.player.health = min(self.player.health + heal, self.player.max_health)
+        print(f"잠을 자고 기력이 회복되었습니다. 체력이 {heal} 회복되었습니다.")
+
+    def wash(self):
+        cost = 2
+        if self.player.money < cost:
+            print("씻을 돈이 부족합니다.")
+            return
+        self.player.money -= cost
+        gain = 30 + self.player.charisma
+        self.player.cleanliness = min(self.player.max_cleanliness, self.player.cleanliness + gain)
+        self.player.stamina -= 5
+        if self.player.stamina < 0:
+            self.player.stamina = 0
+        print("씻고 나니 상쾌합니다.")
+
+    def explore(self):
+        print(f"{self.player.location.name}을 탐험합니다. {self.player.location.description}")
+        roll = random.randint(1, 100)
+        if roll <= 20 + self.player.perception:
+            event = "find_item"
+        elif roll <= 50 + self.player.perception:
+            event = "find_money"
+        elif roll <= 85:
+            event = "nothing"
+        else:
+            event = "injury"
+        if event == "find_item":
+            item = BROKEN_PART
+            self.player.add_item(item)
+        elif event == "find_money":
+            found = random.randint(5, 20) + self.player.charisma
+            self.player.money += found
+            print(f"탐험 중에 {found}원을 발견했습니다.")
+        elif event == "injury":
+            damage = random.randint(5, 15)
+            self.player.health -= damage
+            print(f"탐험 중 부상을 입어 체력이 {damage} 감소했습니다.")
+        else:
+            print("탐험 중 아무 일도 일어나지 않았습니다.")
+
+        stamina_cost = max(5, 15 - self.player.endurance)
+        self.player.stamina -= stamina_cost
+        self.player.satiety -= 5
+        self.player.cleanliness -= 5
+
+        # check for hidden paths
+        loc = self.player.location
+        discovered = [dest for dest, req in loc.hidden_connections.items() if self.player.perception >= req]
+        for dest in discovered:
+            loc.connections.append(dest)
+            dest.connections.append(loc)
+            del loc.hidden_connections[dest]
+            del dest.hidden_connections[loc]
+            print(f"숨겨진 장소 {dest.name}을(를) 발견했습니다!")
+
+    def modify_body(self):
+        print("시술할 개조를 선택하세요:")
+        for i, mod in enumerate(BODY_MODS, start=1):
+            req = f" - 필요 부품: {mod.required_item.name}" if mod.required_item else ""
+            company = f" [{mod.company}]" if mod.company else ""
+            print(f"{i}. {mod.name}{company} (부위: {mod.slot}){req}")
+        choice = input("> ").strip()
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(BODY_MODS):
+                self.player.install_mod(BODY_MODS[idx])
+                return
+        print("잘못된 선택입니다.")
+
+    def move(self):
+        current = self.player.location
+        if not current.connections:
+            print("이곳에서 이동할 수 있는 장소가 없습니다.")
+            return
+        print("이동할 장소를 선택하세요:")
+        for i, dest in enumerate(current.connections, start=1):
+            print(f"{i}. {dest.name}")
+        choice = input("> ").strip()
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(current.connections):
+                dest = current.connections[idx]
+                bag = self.player.equipment.get("bag")
+                if bag and not bag.can_enter_buildings and dest.indoors:
+                    print("대형 카트로는 그곳에 들어갈 수 없습니다.")
+                    return
+                self.player.location = dest
+                print(f"{self.player.location.name}으로 이동했습니다.")
+                return
+        print("잘못된 선택입니다.")
+
+    def interact(self):
+        nearby = [c for c in self.characters if c.location == self.player.location]
+        if not nearby:
+            print("주변에 대화할 사람이 없습니다.")
+            return
+        for i, npc in enumerate(nearby, start=1):
+            print(f"{i}. {npc.name} ({npc.job})")
+        choice = input("> ").strip()
+        if not choice.isdigit():
+            print("잘못된 선택입니다.")
+            return
+        idx = int(choice) - 1
+        if not (0 <= idx < len(nearby)):
+            print("잘못된 선택입니다.")
+            return
+        npc = nearby[idx]
+        print(f"{npc.name}에게 무엇을 하시겠습니까?")
+        print("1. 대화")
+        print("2. 거래")
+        print("3. 돈 빌리기")
+        print("4. 전투")
+        action = input("> ").strip()
+        if action == "1":
+            npc.talk(self.player)
+        elif action == "2":
+            npc.trade(self.player)
+        elif action == "3":
+            npc.lend_money(self.player)
+        elif action == "4":
+            npc.fight(self.player)
+        else:
+            print("잘못된 선택입니다.")
+
+    def travel(self):
+        print("이동할 국가를 선택하세요:")
+        for i, nation in enumerate(NATIONS, start=1):
+            print(f"{i}. {nation.name} - {nation.description}")
+        choice = input("> ").strip()
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(NATIONS):
+                nation = NATIONS[idx]
+                self.player.location = DEFAULT_LOCATION_BY_NATION[nation]
+                print(f"{nation.name}으로 이동했습니다. 현재 위치는 {self.player.location.name}입니다.")
+                return
+        print("잘못된 선택입니다.")
+
+    def step(self, action):
+        action()
+        self.advance_time()
+
+    def choose_move(self):
+        print("1. 장소 이동")
+        print("2. 국가 이동")
+        choice = input("> ").strip()
+        if choice == "1":
+            self.step(self.move)
+        elif choice == "2":
+            self.step(self.travel)
+        else:
+            print("잘못된 선택입니다.")
+
+    def choose_action(self):
+        print("1. 일하기")
+        print("2. 식사")
+        print("3. 잠자기")
+        print("4. 탐험")
+        print("5. 소지품 확인")
+        print("6. 씻기")
+        print("7. 신체 개조")
+        choice = input("> ").strip()
+        actions = {
+            "1": self.work,
+            "2": self.eat,
+            "3": self.sleep,
+            "4": self.explore,
+            "5": self.player.show_inventory,
+            "6": self.wash,
+            "7": self.modify_body,
+        }
+        action = actions.get(choice)
+        if action:
+            if action is self.player.show_inventory:
+                action()
+            else:
+                self.step(action)
+        else:
+            print("잘못된 선택입니다.")
+
+    def open_menu(self):
+        print("1. 종료")
+        print("이전 메뉴로 돌아가려면 엔터를 누르세요")
+        choice = input("> ").strip()
+        if choice == "1":
+            print("게임을 종료합니다.")
+            return False
+        return True
+
+    def play(self):
+        while self.player.is_alive():
+            self.update_characters()
+            draw_screen(self.player, self.characters)
+            print("무엇을 하시겠습니까?")
+            print("1. 이동")
+            print("2. NPC 선택")
+            print("3. 행동")
+            print("4. 메뉴")
+            choice = input("> ").strip()
+            if choice == "1":
+                self.choose_move()
+            elif choice == "2":
+                self.step(self.interact)
+            elif choice == "3":
+                self.choose_action()
+            elif choice == "4":
+                if not self.open_menu():
+                    break
+            else:
+                print("잘못된 선택입니다.")
+        if not self.player.is_alive():
+            print("건강이 나빠 쓰러졌습니다. 게임 오버.")
+
+
+def main():
+    name = input("캐릭터 이름을 입력하세요: ")
+    print("시스템 초기화 중...")
+    print("...")
+    player = Player(name)
+    print("눈을 뜨니 당신은 거대한 하수도에 누워 있습니다.")
+    game = Game(player)
+    game.play()
+
+if __name__ == "__main__":
+    main()

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Simple text interface for FEP.
+
+Displays player status, current location information, and available
+movement options in Korean.
+"""
+
+from characters import NPCS, TIME_OF_DAY
+
+
+def health_message(player):
+    ratio = player.health / player.max_health
+    if ratio > 0.7:
+        return "건강 상태: 양호"
+    elif ratio > 0.4:
+        return "건강 상태: 주의"
+    else:
+        return "건강 상태: 위험"
+
+
+def draw_screen(player, npcs=NPCS):
+    """Print a simple status window and location information."""
+    print(f"{player.day}일차 {TIME_OF_DAY[player.time]}")
+    print(health_message(player))
+    print(
+        f"체력 {player.health}/{player.max_health} "
+        + f"포만감 {player.satiety}/{player.max_satiety} "
+        + f"기력 {player.stamina}/{player.max_stamina} "
+        + f"청결 {player.cleanliness}/{player.max_cleanliness} "
+        + f"돈 {player.money}원 무게 "
+        + (
+            str(player.estimated_weight())
+            if player.perception >= 10
+            else f"약 {player.estimated_weight()}"
+        )
+        + f"/{player.carrying_capacity()}"
+    )
+    print("-" * 30)
+
+    location = player.location
+    print(f"현재 위치: {location.name}")
+    print(location.description)
+    nearby = [c.name for c in npcs if c.location == location]
+    if nearby:
+        print("주변 인물: " + ", ".join(nearby))
+    else:
+        print("주변 인물: 없음")
+    print("-" * 30)
+
+    if location.connections:
+        print("이동 가능 장소:")
+        for dest in location.connections:
+            print(f"- {dest.name}")
+    else:
+        print("이동 가능한 장소가 없습니다.")
+    print()

--- a/items.py
+++ b/items.py
@@ -1,0 +1,25 @@
+import json
+import os
+
+
+class Item:
+    def __init__(self, name, weight, volume=1):
+        self.name = name
+        self.weight = weight
+        self.volume = volume
+
+
+def _load_items():
+    path = os.path.join(os.path.dirname(__file__), "data", "items.json")
+    with open(path, encoding="utf-8") as f:
+        raw = json.load(f)
+    items = {}
+    for key, val in raw.items():
+        items[key] = Item(val["name"], val["weight"], val.get("volume", 1))
+    return items
+
+
+_ITEMS = _load_items()
+globals().update(_ITEMS)
+
+__all__ = ["Item"] + list(_ITEMS.keys())

--- a/locations.py
+++ b/locations.py
@@ -1,0 +1,74 @@
+import json
+import os
+
+
+class Nation:
+    def __init__(self, name, description):
+        self.name = name
+        self.description = description
+
+
+class Location:
+    def __init__(self, name, description, nation, indoors=False):
+        self.name = name
+        self.description = description
+        self.nation = nation
+        self.indoors = indoors
+        self.connections = []
+        self.hidden_connections = {}
+
+    def connect(self, other, required_perception=None):
+        if required_perception is None:
+            if other not in self.connections:
+                self.connections.append(other)
+            if self not in other.connections:
+                other.connections.append(self)
+        else:
+            self.hidden_connections[other] = required_perception
+            other.hidden_connections[self] = required_perception
+
+
+def _load_data():
+    path = os.path.join(os.path.dirname(__file__), "data", "locations.json")
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+data = _load_data()
+
+# Nations
+NATIONS = [Nation(n["name"], n["description"]) for n in data["nations"]]
+
+# Locations
+_locations = {}
+for entry in data["locations"]:
+    nation = NATIONS[entry["nation"]]
+    loc = Location(entry["name"], entry["description"], nation, entry.get("indoors", False))
+    loc.key = entry["key"]
+    _locations[entry["key"]] = loc
+
+# Connections
+for conn in data["connections"]:
+    if isinstance(conn, list):
+        a, b = _locations[conn[0]], _locations[conn[1]]
+        a.connect(b)
+    else:
+        a = _locations[conn["from"]]
+        b = _locations[conn["to"]]
+        a.connect(b, required_perception=conn["perception"])
+
+# Default locations
+DEFAULT_LOCATION_BY_NATION = {NATIONS[int(k)]: _locations[v] for k, v in data["default_locations"].items()}
+
+# Export location variables for convenience
+globals().update(_locations)
+
+LOCATIONS = list(_locations.values()) + list({loc for loc in DEFAULT_LOCATION_BY_NATION.values() if loc not in _locations.values()})
+
+__all__ = [
+    "Nation",
+    "Location",
+    "NATIONS",
+    "DEFAULT_LOCATION_BY_NATION",
+    "LOCATIONS",
+] + list(_locations.keys())


### PR DESCRIPTION
## Summary
- add part items required for cybernetic upgrades
- extend `BodyMod` with part requirements and company info
- implement brain interface and alternate eye mods
- show mod requirements in the body-modification menu
- document companies and part requirements
- load items, locations, and NPCs from JSON data files

## Testing
- `python -m py_compile game.py characters.py locations.py gui.py items.py battle.py equipment.py`
- `python game.py <<'EOF'
Tester
4
1
EOF`
- `python game.py <<'EOF'
Tester
q
EOF` *(fails: EOFError when input ended)*

------
https://chatgpt.com/codex/tasks/task_e_687c8b0ac3bc832ab56437e0f3aa28c2