### PR TITLE
Add conversation replies and skip extra move menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ During the game you will be prompted in Korean to choose among four main categor
 
 ### Player Stats
 
-Characters have seven core attributes:
+Characters have six core attributes:
 
 - **Strength**
 - **Perception**
@@ -61,7 +61,6 @@ Characters have seven core attributes:
 - **Charisma**
 - **Intelligence**
 - **Agility** – higher agility lets your turn gauge fill faster in battle
-- **Intuition** – warns you of looming danger before it strikes
 
 A value around 10 is typical for an average human. Scores above 20 are
 considered exceptional. Unless the player installs a brain-interface
@@ -214,9 +213,9 @@ Big Five 다섯 항목의 높고 낮음을 조합한 32가지 성격 유형별 �
 정부 특수부대에 스카우트되는 특별한 전개도 존재합니다.
 숨기에 성공하더라도 안심할 수는 없습니다. 도망친 뒤 집으로 돌아오면
 집 안에 잠복해 있던 로봇들이 다시 납치를 시도합니다. 지각이 높으면
-집 근처에서 수상한 기운을 느끼거나 직감이 높은 경우 어둠 속 그림자나
-낯선 향기를 통해 위험을 예감해 도망칠 수 있지만, 무시하고 들어가면
-또 한 번 전투가 벌어집니다.
+집 근처에서 수상한 기운이나 어둠 속 그림자, 낯선 향기를 감지해
+위험을 예감하고 도망칠 수 있지만, 무시하고 들어가면 또 한 번 전투가
+벌어집니다.
 
 ### 병원 시스템
 

--- a/battle.py
+++ b/battle.py
@@ -1,5 +1,5 @@
 import random
-from utils import choose_option, roll_check
+from utils import choose_option, roll_check, attach_josa
 from messages import get_message
 
 
@@ -158,7 +158,7 @@ def start_battle(player, npc, ambush=None):
             else:
                 dmg += w_dmg
             if w_type == "둔기" and random.random() < 0.1:
-                print(f"{npc.name}이(가) 머리를 강타하여 당신이 기절합니다!")
+                print(f"{attach_josa(npc.name, '이/가')} 머리를 강타하여 당신이 기절합니다!")
                 gauges[player] += 100
             if attack_hit(npc, player, weapon):
                 if crit_check(npc):

--- a/utils.py
+++ b/utils.py
@@ -57,6 +57,36 @@ def color_text(text: str, code: str) -> str:
     return f"\033[{code}m{text}\033[0m"
 
 
+def attach_josa(word: str, pair: str) -> str:
+    """Return ``word`` appended with the correct Korean particle from ``pair``.
+
+    ``pair`` should be a string like ``"이/가"`` or ``"은/는"``. The function
+    checks whether ``word`` ends with a final consonant to decide which particle
+    to use.
+    """
+    first, second = pair.split("/")
+    last = word[-1]
+    code = ord(last) - 0xAC00
+    if 0 <= code < 11172 and code % 28 != 0:
+        return word + first
+    return word + second
+
+
+STAT_LABELS = {
+    "strength": "근력",
+    "perception": "지각",
+    "endurance": "인내심",
+    "charisma": "매력",
+    "intelligence": "지능",
+    "agility": "민첩",
+}
+
+
+def stat_label(key: str) -> str:
+    """Return the Korean label for a stat key."""
+    return STAT_LABELS.get(key, key)
+
+
 def find_path(start, goal):
     """Return a list of locations from ``start`` to ``goal`` using BFS."""
     from collections import deque


### PR DESCRIPTION
## Summary
- add a simple conversation flow when talking to NPCs
- skip the movement choice menu if only walking is available

## Testing
- `python -m py_compile game.py characters.py battle.py utils.py`
- `python game.py` *(exited via 'exit')*

------
https://chatgpt.com/codex/tasks/task_e_68821334ee28832a910b249c07ad0684